### PR TITLE
Fixes for apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:latest
 MAINTAINER Alan Scherger <flyinprogrammer@gmail.com>
 
-RUN apt-get install -y whois && \
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && \
+    apt-get install -y whois && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 


### PR DESCRIPTION
I discovered this because [recent builds](https://hub.docker.com/r/flyinprogrammer/mkpasswd/builds/) have been failing.

An apt-get update is needed to refresh the package list; otherwise the
package will probably fail to install.

The DEBIAN_FRONTEND=noninteractive is needed to ensure apt make no
attempt at all to prompt for input.
